### PR TITLE
cleaning up compiler warnings

### DIFF
--- a/src/Models/CustomMeteringBadRequestResult.cs
+++ b/src/Models/CustomMeteringBadRequestResult.cs
@@ -11,7 +11,7 @@
 
     public class CustomMeteringBadRequestResult : CustomMeteringRequestResult
     {
-        public string Code { get; set; }
+        public new string Code { get; set; }
         public IEnumerable<CustomerMeterErrorDetails> Details { get; set; }
         public string Message { get; set; }
 

--- a/test/SaaSFulfillmentClientTests/MockApiTests.cs
+++ b/test/SaaSFulfillmentClientTests/MockApiTests.cs
@@ -279,7 +279,7 @@ namespace SaaSFulfillmentClientTests
                 correlationId,
                 cancellationToken: new CancellationTokenSource().Token);
 
-            Assert.NotNull(result.OperationId);
+            Assert.NotEqual(result.OperationId, Guid.Empty);
             Assert.NotNull(result);
             Assert.NotEqual(0, result.RetryAfter);
         }


### PR DESCRIPTION
1. Added new keyword to override the parent
2. Changed test to Assert against Guid as an empty Guid as Guids cannot truly be null