### PR TITLE
Continue paging in other subscriptions in GetSubscriptions.

### DIFF
--- a/src/Models/SubscriptionsResult.cs
+++ b/src/Models/SubscriptionsResult.cs
@@ -86,6 +86,9 @@ namespace SaaSFulfillmentClient.Models
     public class SubscriptionResult : FulfillmentRequestResult
     {
         public string ContinuationToken { get; set; }
-        public IEnumerable<Subscription> Subscriptions { get; set; }
+
+        [JsonProperty("@nextLink")]
+        public string NextLink { get; set; }
+        public IList<Subscription> Subscriptions { get; set; }
     }
 }


### PR DESCRIPTION
Code was not pulling in subscriptions past the 81st one. This change handles the continuation token expressed as @nextLink in the JSON response for GetSubscriptions. 